### PR TITLE
Changes as per EGO code review of version 1, and a fix for the selected player being forgotten

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -1,9 +1,11 @@
 // Lyrion / MPRIS controller GNOME Shell extension
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 import {LmsService} from './lmsService.js';
+import {logInfo} from './logging.js';
 
 export default class LyrionMprisBridgeExtension extends Extension {
   enable() {
+    logInfo('Extension enabled');
     this._settings = this.getSettings();
 
     this._service = new LmsService(this._settings);

--- a/extension/lmsApi.js
+++ b/extension/lmsApi.js
@@ -2,7 +2,7 @@ import GLib from 'gi://GLib';
 import Soup from 'gi://Soup';
 
 import * as Constants from './constants.js';
-import {logDebug, logError} from './logging.js';
+import {logDebug, logWarn, logError} from './logging.js';
 
 export class LmsApi {
   constructor({session} = {}) {
@@ -143,7 +143,7 @@ export class LmsApi {
     const {bytes, status} = await this._sendJsonBody(url, body, auth);
 
     if (status !== Soup.Status.OK) {
-      logError(`LMS command HTTP ${status} for ${logUrl}`);
+      logWarn(`LMS command HTTP ${status} for ${logUrl}`);
     }
     const text = new TextDecoder().decode(bytes.get_data());
     if (!text) {
@@ -160,7 +160,7 @@ export class LmsApi {
         logDebug('LMS command ok');
       }
     } catch (e) {
-      logError(`LMS command response parse error: ${e}`);
+      logWarn(`LMS command response parse error: ${e}`);
     }
   }
 

--- a/extension/logging.js
+++ b/extension/logging.js
@@ -1,17 +1,27 @@
 const LOG_PREFIX = 'LyrionMPRIS';
-let debugEnabled = false;
+let verboseEnabled = false;
 
-export const setDebugEnabled = enabled => {
-  debugEnabled = enabled === true;
+const formatMessage = (level, message) => `${LOG_PREFIX}(${level}): ${message}`;
+
+export const setVerboseEnabled = enabled => {
+  verboseEnabled = enabled === true;
 };
 
 export const logDebug = message => {
-  if (!debugEnabled) {
+  if (!verboseEnabled) {
     return;
   }
-  log(`${LOG_PREFIX}(debug): ${message}`);
+  console.log(formatMessage('debug', message));
+};
+
+export const logInfo = message => {
+  console.log(formatMessage('info', message));
+};
+
+export const logWarn = message => {
+  console.warn(formatMessage('warn', message));
 };
 
 export const logError = message => {
-  log(`${LOG_PREFIX}(error): ${message}`);
+  console.error(formatMessage('error', message));
 };

--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -5,6 +5,6 @@
   "shell-version": [
     "49"
   ],
-  "settings-schema": "org.gnome.shell.extensions.lyrion-mpris-bridge",
+  "settings-schema": "org.gnome.shell.extensions.lyrion-mpris-bridge.calumchisholm.github.io",
   "url": "https://github.com/calumchisholm/lyrion-mpris-bridge"
 }

--- a/extension/mprisPlayerController.js
+++ b/extension/mprisPlayerController.js
@@ -2,7 +2,7 @@ import GLib from 'gi://GLib';
 import Gio from 'gi://Gio';
 
 import * as Constants from './constants.js';
-import {logDebug} from './logging.js';
+import {logInfo, logDebug} from './logging.js';
 import {MprisController, MPRIS_OBJECT_PATH} from './mprisController.js';
 
 const MPRIS_PLAYER_INTERFACE = 'org.mpris.MediaPlayer2.Player';
@@ -195,39 +195,39 @@ export class MprisPlayerController extends MprisController {
   // https://specifications.freedesktop.org/mpris/latest/Player_Interface.html
 
   PlayPause() {
-    logDebug('MPRIS PlayPause');
+    logInfo('MPRIS PlayPause');
     this._playPause?.();
   }
   Play() {
-    logDebug('MPRIS Play');
+    logInfo('MPRIS Play');
     this._play?.();
   }
   Pause() {
-    logDebug('MPRIS Pause');
+    logInfo('MPRIS Pause');
     this._pause?.();
   }
   Stop() {
-    logDebug('MPRIS Stop');
+    logInfo('MPRIS Stop');
     this._stop?.();
   }
   Next() {
-    logDebug('MPRIS Next');
+    logInfo('MPRIS Next');
     this._next?.();
   }
   Previous() {
-    logDebug('MPRIS Previous');
+    logInfo('MPRIS Previous');
     this._previous?.();
   }
   Seek(offset) {
-    logDebug(`MPRIS Seek offset=${offset}`);
+    logInfo(`MPRIS Seek offset=${offset}`);
     this._seek?.(offset);
   }
   SetPosition(trackId, position) {
-    logDebug(`MPRIS SetPosition trackId=${trackId} position=${position}`);
+    logInfo(`MPRIS SetPosition trackId=${trackId} position=${position}`);
     this._setPosition?.(trackId, position);
   }
   OpenUri(uri) {
-    logDebug(`MPRIS OpenUri uri=${uri}`);
+    logInfo(`MPRIS OpenUri uri=${uri}`);
     this._openUri?.(uri);
   }
 

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -158,10 +158,10 @@ export default class LyrionMprisBridgePrefs extends ExtensionPreferences {
     };
 
     const applyPlayerOptions = options => {
+      updatingPlayer = true;
       playerOptions = options;
       playerRow.model = Gtk.StringList.new(options.map(option => option.label));
       playerRow.sensitive = options.length > 1;
-      updatingPlayer = true;
       const selectedId = settings.get_string('player-id');
       const index = options.findIndex(option => option.id === selectedId);
       playerRow.selected = index >= 0 ? index : 0;
@@ -286,18 +286,18 @@ export default class LyrionMprisBridgePrefs extends ExtensionPreferences {
     const groupDiagnostics = new Adw.PreferencesGroup({title: _('Diagnostics')});
     page.add(groupDiagnostics);
 
-    const debugRow = new Adw.ActionRow({
-      title: _('Debug logging'),
+    const verboseRow = new Adw.ActionRow({
+      title: _('Verbose logging'),
       subtitle: _('Log extra LMS and MPRIS details'),
     });
-    const debugSwitch = new Gtk.Switch({
-      active: settings.get_boolean('debug-logging'),
+    const verboseSwitch = new Gtk.Switch({
+      active: settings.get_boolean('verbose-logging'),
       valign: Gtk.Align.CENTER,
     });
-    settings.bind('debug-logging', debugSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
-    debugRow.add_suffix(debugSwitch);
-    debugRow.activatable_widget = debugSwitch;
-    groupDiagnostics.add(debugRow);
+    settings.bind('verbose-logging', verboseSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
+    verboseRow.add_suffix(verboseSwitch);
+    verboseRow.activatable_widget = verboseSwitch;
+    groupDiagnostics.add(verboseRow);
   }
 
   _createEntryRow({title, subtitle, settings, key, entryProps = {}}) {

--- a/extension/schemas/org.gnome.shell.extensions.lyrion-mpris-bridge.calumchisholm.github.io.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.lyrion-mpris-bridge.calumchisholm.github.io.gschema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <schema id="org.gnome.shell.extensions.lyrion-mpris-bridge" path="/org/gnome/shell/extensions/lyrion-mpris-bridge/">
+  <schema id="org.gnome.shell.extensions.lyrion-mpris-bridge.calumchisholm.github.io" path="/org/gnome/shell/extensions/lyrion-mpris-bridge/calumchisholm/github/io/">
     <key name="server-address" type="s">
       <default>'127.0.0.1'</default>
       <summary>Logitech Media Server address</summary>
@@ -46,9 +46,9 @@
       <summary>MPRIS OpenUri action</summary>
       <description>What to do when a client calls OpenUri: open LMS now playing, open the provided URI, or use the provided URI with LMS fallback.</description>
     </key>
-    <key name="debug-logging" type="b">
+    <key name="verbose-logging" type="b">
       <default>false</default>
-      <summary>Enable debug logging</summary>
+      <summary>Enable verbose logging</summary>
       <description>Log extra details for LMS requests and MPRIS interactions.</description>
     </key>
     <key name="allow-artwork-credentials" type="b">

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -23,15 +23,12 @@ TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
 cp -R "${EXT_DIR}/." "${TMP_DIR}/"
-rm -f "${TMP_DIR}/schemas/gschemas.compiled"
-if [[ -d "${TMP_DIR}/schemas" ]]; then
-  glib-compile-schemas "${TMP_DIR}/schemas"
-fi
 
 ZIP_PATH="${DIST_DIR}/${UUID}.zip"
+rm -f "${ZIP_PATH}"
 (
   cd "${TMP_DIR}"
-  zip -r "${ZIP_PATH}" .
+  zip -r "${ZIP_PATH}" . -x "schemas/gschemas.compiled"
 )
 
 echo "Wrote ${ZIP_PATH}"


### PR DESCRIPTION
Use console.* instead of log(), generally reworked logging and use of log categories.
Fixed schema name - now consistent with my excention UUID.
Compiled schema now excluded from zip package (not required for Gnome Shell 45+.

Fixed issue where selected player was being forgotten.